### PR TITLE
Update attend.py by removing the redundant starred expression

### DIFF
--- a/denoising_diffusion_pytorch/attend.py
+++ b/denoising_diffusion_pytorch/attend.py
@@ -68,7 +68,7 @@ class Attend(nn.Module):
             self.cuda_config = AttentionConfig(False, True, True)
 
     def flash_attn(self, q, k, v):
-        _, heads, q_len, _, k_len, is_cuda, device = *q.shape, k.shape[-2], q.is_cuda, q.device
+        _, heads, q_len, _, k_len, is_cuda, device = q.shape, k.shape[-2], q.is_cuda, q.device
 
         if exists(self.scale):
             default_scale = q.shape[-1]


### PR DESCRIPTION
The starred expression used in *q.shape seems to be redundant. It is also surprising that it doesn't cause an error "SyntaxError: can't use starred expression here".